### PR TITLE
feat: add registry validation foundation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+-
+
+## Red Team
+
+- [ ] `git diff --check` passes
+- [ ] Added lines contain no obvious hardcoded secrets
+- [ ] Critical dependency audit passes
+
+## Blue Team
+
+- [ ] Dependencies install with `npm ci`
+- [ ] Registry validation passes
+- [ ] Test suite passes
+
+## Merge readiness
+
+- [ ] `Deployment Readiness` GitHub Actions job is green
+- [ ] This PR is intended to merge through protected `main`, not direct push

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,16 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm run check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,15 +2,73 @@ name: Check
 
 on:
   pull_request:
+    branches: [main]
   push:
     branches: [main]
 
 jobs:
-  registry:
+  red-team:
+    name: Red Team
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Whitespace and patch sanity
+        run: git diff --check origin/main...HEAD || git diff --check HEAD~1..HEAD
+      - name: Scan added lines for hardcoded secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git rev-parse origin/main >/dev/null 2>&1; then
+            RANGE="origin/main...HEAD"
+          else
+            RANGE="HEAD~1..HEAD"
+          fi
+          git diff --unified=0 "$RANGE" > /tmp/changed.diff || true
+          node <<'NODE'
+          const { readFileSync } = require('node:fs');
+          const diff = readFileSync('/tmp/changed.diff', 'utf8');
+          const secretPattern = /^(?!\+\+\+)\+.*\b(api[_-]?key|secret|password|passwd|token|access[_-]?key|private[_-]?key)\b\s*[:=]\s*['"][^'"]{8,}['"]/i;
+          const matches = diff.split('\n').filter((line) => secretPattern.test(line));
+          if (matches.length) {
+            console.error('Potential hardcoded secret(s) found in added lines:');
+            for (const line of matches) console.error(line);
+            process.exit(1);
+          }
+          console.log('No obvious hardcoded secrets in added lines.');
+          NODE
+      - name: Critical dependency audit
+        run: npm audit --audit-level=critical
+
+  blue-team:
+    name: Blue Team
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npm run check
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Registry and test gate
+        run: npm run check
+
+  deployment-readiness:
+    name: Deployment Readiness
+    runs-on: ubuntu-latest
+    needs: [red-team, blue-team]
+    if: always()
+    steps:
+      - name: Fail closed unless Red and Blue teams passed
+        run: |
+          if [ "${{ needs.red-team.result }}" != "success" ] || [ "${{ needs.blue-team.result }}" != "success" ]; then
+            echo "Red Team result: ${{ needs.red-team.result }}"
+            echo "Blue Team result: ${{ needs.blue-team.result }}"
+            exit 1
+          fi
+          echo "Red Team and Blue Team gates passed. Ready to merge."

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.DS_Store
+.env
+coverage/
+dist/
+.tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+
+- Add machine-readable module, variable, and modifier registries.
+- Add Node-based data validation and test scripts.
+- Add GitHub Actions CI for registry checks.
+- Add MIT license and contribution guide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+Thanks for improving Cafe24 Smart Design references.
+
+## Development
+
+```bash
+npm install
+npm run check
+```
+
+## Registry rules
+
+- Add new modules to `data/modules.json`.
+- Add new variables to `data/variables.json`.
+- Add new modifiers to `data/modifiers.json`.
+- Include a source field for every entry. Prefer Cafe24 official docs when available.
+- Run `npm run validate:data` before opening a PR.
+
+## Documentation
+
+The Markdown files in `references/` are the human-readable reference. Keep them aligned with `data/` until full generation is added.
+
+## Pull requests
+
+Use small PRs and include:
+
+- What changed
+- Source/verification notes
+- Test output

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Youngwoo Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ cat /tmp/cafe24-ref/SKILL.md /tmp/cafe24-ref/references/*.md \
 
 ---
 
+## 개발 / 검증
+
+이 저장소는 문서뿐 아니라 AI 도구가 재사용할 수 있는 machine-readable registry를 함께 제공합니다.
+
+```bash
+npm install
+npm run check
+```
+
+주요 데이터 파일:
+
+```
+data/
+├── modules.json      # 카페24 모듈 레지스트리
+├── variables.json    # 변수 레지스트리
+└── modifiers.json    # 수정자 레지스트리
+```
+
+`npm run validate:data`는 모듈/변수/수정자 중복, 필수 필드, 모듈-변수 참조 무결성을 검사합니다.
+
+---
+
 ## 라이선스
 
 MIT

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ data/
 
 `npm run validate:data`는 모듈/변수/수정자 중복, 필수 필드, 모듈-변수 참조 무결성을 검사합니다.
 
+### Red Team / Blue Team 머지 게이트
+
+PR은 GitHub Actions의 `Red Team`, `Blue Team`, `Deployment Readiness` 세 가지 게이트를 통과해야 자동 머지될 수 있습니다.
+자세한 운영 방식은 [`docs/red-blue-merge-gates.md`](docs/red-blue-merge-gates.md)를 참고하세요.
+
 ---
 
 ## 라이선스

--- a/data/modifiers.json
+++ b/data/modifiers.json
@@ -1,0 +1,93 @@
+[
+  {
+    "name": "cut",
+    "purpose": "String truncation",
+    "syntax": "{$v|cut:length,suffix}",
+    "example": "{$product_name|cut:20,...}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "numberformat",
+    "purpose": "Thousands separator",
+    "syntax": "{$v|numberformat}",
+    "example": "{$product_price|numberformat}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "date",
+    "purpose": "Date format",
+    "syntax": "{$v|date:Y-m-d}",
+    "example": "{$write_date|date:Y.m.d}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "display",
+    "purpose": "false -> display:none",
+    "syntax": "{$v|display}",
+    "example": "class=\"{$soldout_icon|display}\"",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "cover",
+    "purpose": "Wrap string",
+    "syntax": "{$v|cover:before,after}",
+    "example": "{$subject|cover:[,]}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "replace",
+    "purpose": "String replace",
+    "syntax": "{$v|replace:find,replace}",
+    "example": "{$notice_icon|replace:notice,NOTICE}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "strconv",
+    "purpose": "String convert",
+    "syntax": "{$v|strconv:text}",
+    "example": "{$new_icon|strconv:NEW}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "imgconv",
+    "purpose": "Image tag convert",
+    "syntax": "{$v|imgconv:path}",
+    "example": "{$name_or_img_tag|imgconv:'/img/a.png'}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "nl2br",
+    "purpose": "Newline -> <br>",
+    "syntax": "{$v|nl2br}",
+    "example": "{$content|nl2br}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "striptag",
+    "purpose": "Remove HTML tags",
+    "syntax": "{$v|striptag}",
+    "example": "{$content|striptag}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "timetodate",
+    "purpose": "Timestamp -> date",
+    "syntax": "{$v|timetodate:Y-m-d}",
+    "example": "{$write_date|timetodate:Y-m-d}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "lower",
+    "purpose": "To lowercase",
+    "syntax": "{$v|lower}",
+    "example": "{$category_name|lower}",
+    "source": "references/modifiers-and-syntax.md"
+  },
+  {
+    "name": "upper",
+    "purpose": "To uppercase",
+    "syntax": "{$v|upper}",
+    "example": "{$category_name|upper}",
+    "source": "references/modifiers-and-syntax.md"
+  }
+]

--- a/data/modules.json
+++ b/data/modules.json
@@ -1,0 +1,740 @@
+[
+  {
+    "id": "Layout_LogoTop",
+    "category": "layout-(layout.html)",
+    "description": "Shop logo (top)",
+    "variables": [
+      "mall_name",
+      "mobile_title"
+    ],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Layout_category",
+    "category": "layout-(layout.html)",
+    "description": "Product category menu",
+    "variables": [
+      "name_or_img_tag",
+      "link_product_list",
+      "param_cate_no"
+    ],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Layout_SearchHeader",
+    "category": "layout-(layout.html)",
+    "description": "Product search (top)",
+    "variables": [
+      "form.search",
+      "action_search"
+    ],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Layout_statelogon",
+    "category": "layout-(layout.html)",
+    "description": "Logged-in state display",
+    "variables": [
+      "name",
+      "basket_cnt"
+    ],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Layout_statelogoff",
+    "category": "layout-(layout.html)",
+    "description": "Logged-out state display",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Layout_shoppingInfo",
+    "category": "layout-(layout.html)",
+    "description": "Cart/mileage/wishlist info",
+    "variables": [
+      "basket_cnt",
+      "mylikeprd_total_cnt",
+      "interest_prd_cnt"
+    ],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Layout_orderBasketcount",
+    "category": "layout-(layout.html)",
+    "description": "Cart item count",
+    "variables": [
+      "basket_cnt"
+    ],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Layout_MobileAction",
+    "category": "layout-(layout.html)",
+    "description": "Mobile back navigation",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_listmain_1",
+    "category": "product",
+    "description": "Main recommended products",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_listmain_2",
+    "category": "product",
+    "description": "Main new products",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_listmain_3",
+    "category": "product",
+    "description": "Main additional category 1",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_listmain_4",
+    "category": "product",
+    "description": "Main additional category 2",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_listmain_5",
+    "category": "product",
+    "description": "Additional display (order 1)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_headcategory",
+    "category": "product",
+    "description": "Category breadcrumb + title/banner",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_displaycategory",
+    "category": "product",
+    "description": "Sub-category menu",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_children",
+    "category": "product",
+    "description": "Category child menu",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_listrecommend",
+    "category": "product",
+    "description": "Category recommended products",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_listnew",
+    "category": "product",
+    "description": "Category new products",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_listnormal",
+    "category": "product",
+    "description": "Normal product list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_ListItem",
+    "category": "product",
+    "description": "Product list display items (common)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_normalmenu",
+    "category": "product",
+    "description": "Product sort/search/compare",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_normalpaging",
+    "category": "product",
+    "description": "Product list pagination",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_FirstSelect",
+    "category": "product",
+    "description": "Conditional search first select",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_SecondSelect",
+    "category": "product",
+    "description": "Conditional search second select",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_Colorchip",
+    "category": "product",
+    "description": "Color chip preview",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_Orderby",
+    "category": "product",
+    "description": "Product sort function",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_detail",
+    "category": "product",
+    "description": "Product main info (name, price, shipping) + purchase",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_image",
+    "category": "product",
+    "description": "Product image + zoom",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Product_mobileImage",
+    "category": "product",
+    "description": "Mobile product image",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_addimage",
+    "category": "product",
+    "description": "Additional product images (thumbnails)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_option",
+    "category": "product",
+    "description": "Basic product options (color, size, etc.)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_addoption",
+    "category": "product",
+    "description": "Additional input options",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_fileoption",
+    "category": "product",
+    "description": "File upload options",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_noneoption",
+    "category": "product",
+    "description": "No-option product quantity select",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_action",
+    "category": "product",
+    "description": "Buy/cart/wishlist buttons",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_setproduct",
+    "category": "product",
+    "description": "Set product display",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_addproduct",
+    "category": "product",
+    "description": "Additional product display",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_additional",
+    "category": "product",
+    "description": "Product additional info",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_detaildesign",
+    "category": "product",
+    "description": "Product detail content (editor)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_relation",
+    "category": "product",
+    "description": "Related products area",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_relationlist",
+    "category": "product",
+    "description": "Related products list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_review",
+    "category": "product",
+    "description": "Product review list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_reviewpaging",
+    "category": "product",
+    "description": "Review pagination",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_qna",
+    "category": "product",
+    "description": "Product Q&A list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "product_qnapaging",
+    "category": "product",
+    "description": "Q&A pagination",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "coupon_productdetail",
+    "category": "product",
+    "description": "Product detail coupon display",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "myshop_benefit",
+    "category": "product",
+    "description": "Member discount/mileage info",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_TabInfo",
+    "category": "order-cart",
+    "description": "Domestic/international product tabs",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_Empty",
+    "category": "order-cart",
+    "description": "Empty cart notice",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_EmptyItem",
+    "category": "order-cart",
+    "description": "Cart product info",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_BasketOption",
+    "category": "order-cart",
+    "description": "Discount amount info",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_NormTitle",
+    "category": "order-cart",
+    "description": "Normal product title",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_NormNormal",
+    "category": "order-cart",
+    "description": "Normal product (standard shipping)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_list",
+    "category": "order-cart",
+    "description": "Product list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_optionAll",
+    "category": "order-cart",
+    "description": "All options",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_optionList",
+    "category": "order-cart",
+    "description": "Option list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_optionAddList",
+    "category": "order-cart",
+    "description": "Additional option list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_SuppNormal",
+    "category": "order-cart",
+    "description": "Normal product (supplier shipping)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_NormIndividual",
+    "category": "order-cart",
+    "description": "Normal product (individual shipping)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_NormOverseaTitle",
+    "category": "order-cart",
+    "description": "International shipping title",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_NormOversea",
+    "category": "order-cart",
+    "description": "Normal product (international shipping)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_InstTitle",
+    "category": "order-cart",
+    "description": "Interest-free product title",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_InstNormal",
+    "category": "order-cart",
+    "description": "Interest-free product (standard shipping)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_form",
+    "category": "order-cart",
+    "description": "Order form main module",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_normallist",
+    "category": "order-cart",
+    "description": "Standard shipping product list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_optionSet",
+    "category": "order-cart",
+    "description": "Product option setting",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_individuallist",
+    "category": "order-cart",
+    "description": "Individual shipping product list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_oversealist",
+    "category": "order-cart",
+    "description": "International shipping product list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_DeliveryList",
+    "category": "order-cart",
+    "description": "Delivery address selection list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "Order_ordadd",
+    "category": "order-cart",
+    "description": "Additional info input",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "member_login",
+    "category": "member",
+    "description": "Login form (full screen)",
+    "variables": [
+      "form.member_id",
+      "form.member_passwd",
+      "action_func_login",
+      "returnUrl"
+    ],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "member_join",
+    "category": "member",
+    "description": "Sign-up form",
+    "variables": [
+      "form.member_id"
+    ],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "member_modify",
+    "category": "member",
+    "description": "Profile edit",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "member_find",
+    "category": "member",
+    "description": "Find ID/password",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "MyShop_OrderHistoryNologin",
+    "category": "member",
+    "description": "Non-member order lookup",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_title_{no}",
+    "category": "board",
+    "description": "Board title/info",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_category",
+    "category": "board",
+    "description": "Board category classification",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_ReplySort",
+    "category": "board",
+    "description": "Comment sort",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_listheader_{no}",
+    "category": "board",
+    "description": "List header (title, author, date columns)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_notice_{no}",
+    "category": "board",
+    "description": "Notice list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_fixed_{no}",
+    "category": "board",
+    "description": "Pinned posts",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_list_{no}",
+    "category": "board",
+    "description": "Normal post list",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_ButtonList_{no}",
+    "category": "board",
+    "description": "Write button etc.",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_paging_{no}",
+    "category": "board",
+    "description": "Pagination",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_catemove_{no}",
+    "category": "board",
+    "description": "Category/board move",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_function_{no}",
+    "category": "board",
+    "description": "Board functions (move, copy)",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_search_{no}",
+    "category": "board",
+    "description": "Board search",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_listpackage_5",
+    "category": "board",
+    "description": "Free board package",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  },
+  {
+    "id": "board_listpackage_6",
+    "category": "board",
+    "description": "Product Q&A package",
+    "variables": [],
+    "source": "references/modules.md",
+    "status": "documented"
+  }
+]

--- a/data/variables.json
+++ b/data/variables.json
@@ -1,0 +1,1554 @@
+[
+  {
+    "name": "product_no",
+    "syntax": "{$product_no}",
+    "domain": "product-basic-info",
+    "description": "Product number",
+    "usage": "List, Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_name",
+    "syntax": "{$product_name}",
+    "domain": "product-basic-info",
+    "description": "Product name",
+    "usage": "List, Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_name_title",
+    "syntax": "{$product_name_title}",
+    "domain": "product-basic-info",
+    "description": "Product name (for title attr)",
+    "usage": "List",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_name_title_display",
+    "syntax": "{$product_name_title_display}",
+    "domain": "product-basic-info",
+    "description": "Product name title display toggle",
+    "usage": "List",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "name",
+    "syntax": "{$name}",
+    "domain": "product-basic-info",
+    "description": "Product name (detail page)",
+    "usage": "Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_code",
+    "syntax": "{$product_code}",
+    "domain": "product-basic-info",
+    "description": "Product code",
+    "usage": "Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_custom",
+    "syntax": "{$product_custom}",
+    "domain": "product-basic-info",
+    "description": "Custom product info",
+    "usage": "Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param",
+    "syntax": "{$param}",
+    "domain": "product-basic-info",
+    "description": "Product parameter (for links)",
+    "usage": "List",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "link_product_detail",
+    "syntax": "{$link_product_detail}",
+    "domain": "product-basic-info",
+    "description": "Product detail page link",
+    "usage": "List",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "link_product_list",
+    "syntax": "{$link_product_list}",
+    "domain": "product-basic-info",
+    "description": "Category product list link",
+    "usage": "Category",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_price",
+    "syntax": "{$product_price}",
+    "domain": "product-price",
+    "description": "Product price (retail)",
+    "usage": "List, Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_sale_price",
+    "syntax": "{$product_sale_price}",
+    "domain": "product-price",
+    "description": "Sale price (discounted)",
+    "usage": "List, Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_price_mobile",
+    "syntax": "{$product_price_mobile}",
+    "domain": "product-price",
+    "description": "Mobile product price",
+    "usage": "Mobile Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "mobile_dc_price",
+    "syntax": "{$mobile_dc_price}",
+    "domain": "product-price",
+    "description": "Mobile discount price",
+    "usage": "Mobile Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "mileage_value",
+    "syntax": "{$mileage_value}",
+    "domain": "product-price",
+    "description": "Mileage/points",
+    "usage": "Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "dc_price",
+    "syntax": "{$dc_price}",
+    "domain": "product-price",
+    "description": "Member discount price",
+    "usage": "Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "dc_min_price",
+    "syntax": "{$dc_min_price}",
+    "domain": "product-price",
+    "description": "Minimum discount price",
+    "usage": "Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "display_product_sale_price",
+    "syntax": "{$display_product_sale_price}",
+    "domain": "product-price",
+    "description": "Sale price display toggle",
+    "usage": "Cart",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "image_big",
+    "syntax": "{$image_big}",
+    "domain": "product-image",
+    "description": "Main image (large)",
+    "usage": "Product Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "big_img",
+    "syntax": "{$big_img}",
+    "domain": "product-image",
+    "description": "Detail page main image",
+    "usage": "Product Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "image_medium",
+    "syntax": "{$image_medium}",
+    "domain": "product-image",
+    "description": "List image (most used)",
+    "usage": "Product List",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "image_small",
+    "syntax": "{$image_small}",
+    "domain": "product-image",
+    "description": "Small image (thumbnail)",
+    "usage": "Detail bottom",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "image_tiny",
+    "syntax": "{$image_tiny}",
+    "domain": "product-image",
+    "description": "Tiny list image",
+    "usage": "Recently viewed",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "zoom_param",
+    "syntax": "{$zoom_param}",
+    "domain": "product-image",
+    "description": "Image zoom parameter",
+    "usage": "Detail",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "top_image1_tag",
+    "syntax": "{$top_image1_tag}",
+    "domain": "product-image",
+    "description": "Category top image 1",
+    "usage": "List",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "top_image2_tag",
+    "syntax": "{$top_image2_tag}",
+    "domain": "product-image",
+    "description": "Category top image 2",
+    "usage": "List",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "top_image3_tag",
+    "syntax": "{$top_image3_tag}",
+    "domain": "product-image",
+    "description": "Category top image 3",
+    "usage": "List",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "soldout_icon",
+    "syntax": "{$soldout_icon}",
+    "domain": "product-status/icons",
+    "description": "Sold out icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "recommend_icon",
+    "syntax": "{$recommend_icon}",
+    "domain": "product-status/icons",
+    "description": "Recommended icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "new_icon",
+    "syntax": "{$new_icon}",
+    "domain": "product-status/icons",
+    "description": "New product icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "sale_icon",
+    "syntax": "{$sale_icon}",
+    "domain": "product-status/icons",
+    "description": "Sale icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_icons",
+    "syntax": "{$product_icons}",
+    "domain": "product-status/icons",
+    "description": "Product icons collection",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "option_preview_icon",
+    "syntax": "{$option_preview_icon}",
+    "domain": "product-status/icons",
+    "description": "Option preview icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "basket_icon",
+    "syntax": "{$basket_icon}",
+    "domain": "product-status/icons",
+    "description": "Cart icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "zoom_icon",
+    "syntax": "{$zoom_icon}",
+    "domain": "product-status/icons",
+    "description": "Zoom icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "delvtype_display",
+    "syntax": "{$delvtype_display}",
+    "domain": "product-status/icons",
+    "description": "Delivery type display",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "option_name",
+    "syntax": "{$option_name}",
+    "domain": "product-options",
+    "description": "Option name (color, size, etc.)",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "option_value",
+    "syntax": "{$option_value}",
+    "domain": "product-options",
+    "description": "Option value",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "option_maxlength",
+    "syntax": "{$option_maxlength}",
+    "domain": "product-options",
+    "description": "Option max character length",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "add_option_name",
+    "syntax": "{$add_option_name}",
+    "domain": "product-options",
+    "description": "Additional option name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "file_option_name",
+    "syntax": "{$file_option_name}",
+    "domain": "product-options",
+    "description": "File option name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.option",
+    "syntax": "{$form.option}",
+    "domain": "product-options",
+    "description": "Basic option form",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.add_option",
+    "syntax": "{$form.add_option}",
+    "domain": "product-options",
+    "description": "Additional option form",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.option_value",
+    "syntax": "{$form.option_value}",
+    "domain": "product-options",
+    "description": "Option value form",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "quantity",
+    "syntax": "{$quantity}",
+    "domain": "product-options",
+    "description": "Quantity",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "color",
+    "syntax": "{$color}",
+    "domain": "product-options",
+    "description": "Color chip color value",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "option_str",
+    "syntax": "{$option_str}",
+    "domain": "product-options",
+    "description": "Option string",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_detail",
+    "syntax": "{$product_detail}",
+    "domain": "product-detail-shipping",
+    "description": "Product detail description",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "item_display",
+    "syntax": "{$item_display}",
+    "domain": "product-detail-shipping",
+    "description": "Item display toggle",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "item_title",
+    "syntax": "{$item_title}",
+    "domain": "product-detail-shipping",
+    "description": "Item title",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "item_title_display",
+    "syntax": "{$item_title_display}",
+    "domain": "product-detail-shipping",
+    "description": "Item title display toggle",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "item_content",
+    "syntax": "{$item_content}",
+    "domain": "product-detail-shipping",
+    "description": "Item content",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "supply_info",
+    "syntax": "{$supply_info}",
+    "domain": "product-detail-shipping",
+    "description": "Supplier info",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "payment_info",
+    "syntax": "{$payment_info}",
+    "domain": "product-detail-shipping",
+    "description": "Payment info",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "shipping_method",
+    "syntax": "{$shipping_method}",
+    "domain": "product-detail-shipping",
+    "description": "Shipping method",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "shipping_area",
+    "syntax": "{$shipping_area}",
+    "domain": "product-detail-shipping",
+    "description": "Shipping area",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "shipping",
+    "syntax": "{$shipping}",
+    "domain": "product-detail-shipping",
+    "description": "Shipping fee",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "delivery",
+    "syntax": "{$delivery}",
+    "domain": "product-detail-shipping",
+    "description": "Delivery info",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "delivery_price",
+    "syntax": "{$delivery_price}",
+    "domain": "product-detail-shipping",
+    "description": "Delivery price",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_buy",
+    "syntax": "{$action_buy}",
+    "domain": "product-actions-(buy/cart)",
+    "description": "Buy now",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_basket",
+    "syntax": "{$action_basket}",
+    "domain": "product-actions-(buy/cart)",
+    "description": "Add to cart",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_wishlist",
+    "syntax": "{$action_wishlist}",
+    "domain": "product-actions-(buy/cart)",
+    "description": "Add to wishlist",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_recommend",
+    "syntax": "{$action_recommend}",
+    "domain": "product-actions-(buy/cart)",
+    "description": "Recommend",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "category_name",
+    "syntax": "{$category_name}",
+    "domain": "category",
+    "description": "Category name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "category_title_text",
+    "syntax": "{$category_title_text}",
+    "domain": "category",
+    "description": "Category title text",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "category_title_text_display",
+    "syntax": "{$category_title_text_display}",
+    "domain": "category",
+    "description": "Title text display toggle",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "category_title_img",
+    "syntax": "{$category_title_img}",
+    "domain": "category",
+    "description": "Category title image",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "category_title_img_display",
+    "syntax": "{$category_title_img_display}",
+    "domain": "category",
+    "description": "Title image display toggle",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "title_text_or_image",
+    "syntax": "{$title_text_or_image}",
+    "domain": "category",
+    "description": "Text or image title",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "name_or_img_tag",
+    "syntax": "{$name_or_img_tag}",
+    "domain": "category",
+    "description": "Category name or image",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_count",
+    "syntax": "{$product_count}",
+    "domain": "category",
+    "description": "Product count in category",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_count_display",
+    "syntax": "{$product_count_display}",
+    "domain": "category",
+    "description": "Product count display toggle",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "children_icon",
+    "syntax": "{$children_icon}",
+    "domain": "category",
+    "description": "Sub-category icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "disp_cate_1",
+    "syntax": "{$disp_cate_1}",
+    "domain": "category",
+    "description": "Category depth 1~4 display",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "disp_cate_2",
+    "syntax": "{$disp_cate_2}",
+    "domain": "category",
+    "description": "Category depth 1~4 display",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "disp_cate_3",
+    "syntax": "{$disp_cate_3}",
+    "domain": "category",
+    "description": "Category depth 1~4 display",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "disp_cate_4",
+    "syntax": "{$disp_cate_4}",
+    "domain": "category",
+    "description": "Category depth 1~4 display",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "name_1",
+    "syntax": "{$name_1}",
+    "domain": "category",
+    "description": "Category depth 1~4 name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "name_2",
+    "syntax": "{$name_2}",
+    "domain": "category",
+    "description": "Category depth 1~4 name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "name_3",
+    "syntax": "{$name_3}",
+    "domain": "category",
+    "description": "Category depth 1~4 name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "name_4",
+    "syntax": "{$name_4}",
+    "domain": "category",
+    "description": "Category depth 1~4 name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_1",
+    "syntax": "{$param_1}",
+    "domain": "category",
+    "description": "Category depth 1~4 parameter",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_2",
+    "syntax": "{$param_2}",
+    "domain": "category",
+    "description": "Category depth 1~4 parameter",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_3",
+    "syntax": "{$param_3}",
+    "domain": "category",
+    "description": "Category depth 1~4 parameter",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_4",
+    "syntax": "{$param_4}",
+    "domain": "category",
+    "description": "Category depth 1~4 parameter",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_cate_no",
+    "syntax": "{$param_cate_no}",
+    "domain": "category",
+    "description": "Category number parameter",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_count",
+    "syntax": "{$total_count}",
+    "domain": "sort-pagination",
+    "description": "Total product count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_first",
+    "syntax": "{$param_first}",
+    "domain": "sort-pagination",
+    "description": "First page link",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_before",
+    "syntax": "{$param_before}",
+    "domain": "sort-pagination",
+    "description": "Previous page link",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_next",
+    "syntax": "{$param_next}",
+    "domain": "sort-pagination",
+    "description": "Next page link",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_last",
+    "syntax": "{$param_last}",
+    "domain": "sort-pagination",
+    "description": "Last page link",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_class",
+    "syntax": "{$param_class}",
+    "domain": "sort-pagination",
+    "description": "Current page class",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "no",
+    "syntax": "{$no}",
+    "domain": "sort-pagination",
+    "description": "Page number",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_num",
+    "syntax": "{$param_num}",
+    "domain": "sort-pagination",
+    "description": "Page number parameter",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "selected",
+    "syntax": "{$selected}",
+    "domain": "sort-pagination",
+    "description": "Selected state",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "value",
+    "syntax": "{$value}",
+    "domain": "sort-pagination",
+    "description": "Option value",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "title",
+    "syntax": "{$title}",
+    "domain": "sort-pagination",
+    "description": "Option title",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "basket_cnt",
+    "syntax": "{$basket_cnt}",
+    "domain": "shopping-info",
+    "description": "Cart item count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "mylikeprd_total_cnt",
+    "syntax": "{$mylikeprd_total_cnt}",
+    "domain": "shopping-info",
+    "description": "Liked products count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "interest_prd_cnt",
+    "syntax": "{$interest_prd_cnt}",
+    "domain": "shopping-info",
+    "description": "Wishlist product count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "mall_name",
+    "syntax": "{$mall_name}",
+    "domain": "shopping-info",
+    "description": "Shop name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "mobile_title",
+    "syntax": "{$mobile_title}",
+    "domain": "shopping-info",
+    "description": "Mobile title",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "basket_count",
+    "syntax": "{$basket_count}",
+    "domain": "cart-variables",
+    "description": "Cart product count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "item_total",
+    "syntax": "{$item_total}",
+    "domain": "cart-variables",
+    "description": "Item total",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "img",
+    "syntax": "{$img}",
+    "domain": "cart-variables",
+    "description": "Product image",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.quantity",
+    "syntax": "{$form.quantity}",
+    "domain": "cart-variables",
+    "description": "Quantity input",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "mileage",
+    "syntax": "{$mileage}",
+    "domain": "cart-variables",
+    "description": "Mileage",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "discount",
+    "syntax": "{$discount}",
+    "domain": "cart-variables",
+    "description": "Discount amount",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "delv_price_front",
+    "syntax": "{$delv_price_front}",
+    "domain": "cart-variables",
+    "description": "Shipping (primary currency)",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "delv_price_back",
+    "syntax": "{$delv_price_back}",
+    "domain": "cart-variables",
+    "description": "Shipping (secondary currency)",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "delv_type",
+    "syntax": "{$delv_type}",
+    "domain": "cart-variables",
+    "description": "Delivery type",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "sum_price_front",
+    "syntax": "{$sum_price_front}",
+    "domain": "cart-variables",
+    "description": "Subtotal (primary currency)",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "sum_price_back",
+    "syntax": "{$sum_price_back}",
+    "domain": "cart-variables",
+    "description": "Subtotal (secondary currency)",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_product_price",
+    "syntax": "{$total_product_price}",
+    "domain": "cart-variables",
+    "description": "Total product amount",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_option_price",
+    "syntax": "{$total_option_price}",
+    "domain": "cart-variables",
+    "description": "Total option amount",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_delv_price",
+    "syntax": "{$total_delv_price}",
+    "domain": "cart-variables",
+    "description": "Total shipping",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_sum_price_front",
+    "syntax": "{$total_sum_price_front}",
+    "domain": "cart-variables",
+    "description": "Grand total (primary currency)",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_sum_price_back",
+    "syntax": "{$total_sum_price_back}",
+    "domain": "cart-variables",
+    "description": "Grand total (secondary currency)",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_modify",
+    "syntax": "{$action_modify}",
+    "domain": "cart-variables",
+    "description": "Modify action",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_option_change",
+    "syntax": "{$action_option_change}",
+    "domain": "cart-variables",
+    "description": "Option change",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_wish_item",
+    "syntax": "{$action_wish_item}",
+    "domain": "cart-variables",
+    "description": "Move to wishlist",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_buy_item",
+    "syntax": "{$action_buy_item}",
+    "domain": "cart-variables",
+    "description": "Buy selected items",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_image",
+    "syntax": "{$product_image}",
+    "domain": "order-form-variables",
+    "description": "Product image",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_price_front",
+    "syntax": "{$product_price_front}",
+    "domain": "order-form-variables",
+    "description": "Product price",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_quantity_text",
+    "syntax": "{$product_quantity_text}",
+    "domain": "order-form-variables",
+    "description": "Quantity text",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "product_total_price_front",
+    "syntax": "{$product_total_price_front}",
+    "domain": "order-form-variables",
+    "description": "Product subtotal",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.oname",
+    "syntax": "{$form.oname}",
+    "domain": "order-form-variables",
+    "description": "Orderer name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.ozipcode1",
+    "syntax": "{$form.ozipcode1}",
+    "domain": "order-form-variables",
+    "description": "Orderer zip code",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.oaddr1",
+    "syntax": "{$form.oaddr1}",
+    "domain": "order-form-variables",
+    "description": "Orderer address",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.ophone1_",
+    "syntax": "{$form.ophone1_}",
+    "domain": "order-form-variables",
+    "description": "Orderer phone",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.oemail",
+    "syntax": "{$form.oemail}",
+    "domain": "order-form-variables",
+    "description": "Orderer email",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.rname",
+    "syntax": "{$form.rname}",
+    "domain": "order-form-variables",
+    "description": "Recipient name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.rzipcode1",
+    "syntax": "{$form.rzipcode1}",
+    "domain": "order-form-variables",
+    "description": "Recipient zip code",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.raddr1",
+    "syntax": "{$form.raddr1}",
+    "domain": "order-form-variables",
+    "description": "Recipient address",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_price",
+    "syntax": "{$total_price}",
+    "domain": "order-form-variables",
+    "description": "Total payment amount",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_order_price_front",
+    "syntax": "{$total_order_price_front}",
+    "domain": "order-form-variables",
+    "description": "Total order amount",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "coupon_cnt",
+    "syntax": "{$coupon_cnt}",
+    "domain": "order-form-variables",
+    "description": "Available coupon count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_avail_mileage",
+    "syntax": "{$total_avail_mileage}",
+    "domain": "order-form-variables",
+    "description": "Available mileage",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "total_deposit",
+    "syntax": "{$total_deposit}",
+    "domain": "order-form-variables",
+    "description": "Available deposit",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "addr_paymethod",
+    "syntax": "{$addr_paymethod}",
+    "domain": "order-form-variables",
+    "description": "Payment method",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "pname",
+    "syntax": "{$pname}",
+    "domain": "order-form-variables",
+    "description": "Bank name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "bankaccount",
+    "syntax": "{$bankaccount}",
+    "domain": "order-form-variables",
+    "description": "Account number",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "item_count",
+    "syntax": "{$item_count}",
+    "domain": "order-form-variables",
+    "description": "Item count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "price_unit_head",
+    "syntax": "{$price_unit_head}",
+    "domain": "order-form-variables",
+    "description": "Currency unit",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "mileage_name",
+    "syntax": "{$mileage_name}",
+    "domain": "order-form-variables",
+    "description": "Mileage name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "member_name",
+    "syntax": "{$member_name}",
+    "domain": "member-info",
+    "description": "Member name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "group_name",
+    "syntax": "{$group_name}",
+    "domain": "member-info",
+    "description": "Member grade name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "member_login_module_id",
+    "syntax": "{$member_login_module_id}",
+    "domain": "member-info",
+    "description": "Login module ID",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "member_login_tab_display",
+    "syntax": "{$member_login_tab_display}",
+    "domain": "member-info",
+    "description": "Login tab display",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.member_id",
+    "syntax": "{$form.member_id}",
+    "domain": "member-info",
+    "description": "Member ID input",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.member_passwd",
+    "syntax": "{$form.member_passwd}",
+    "domain": "member-info",
+    "description": "Password input",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.use_login_keeping",
+    "syntax": "{$form.use_login_keeping}",
+    "domain": "member-info",
+    "description": "Keep logged in",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.check_save_id",
+    "syntax": "{$form.check_save_id}",
+    "domain": "member-info",
+    "description": "Save ID",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_func_login",
+    "syntax": "{$action_func_login}",
+    "domain": "member-info",
+    "description": "Login action",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "returnUrl",
+    "syntax": "{$returnUrl}",
+    "domain": "member-info",
+    "description": "Return URL after login",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "display_nomember",
+    "syntax": "{$display_nomember}",
+    "domain": "member-info",
+    "description": "Non-member order display toggle",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_nomember_order",
+    "syntax": "{$action_nomember_order}",
+    "domain": "member-info",
+    "description": "Non-member order action",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "board_name",
+    "syntax": "{$board_name}",
+    "domain": "board-variables",
+    "description": "Board name",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "board_title",
+    "syntax": "{$board_title}",
+    "domain": "board-variables",
+    "description": "Board title",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "board_info",
+    "syntax": "{$board_info}",
+    "domain": "board-variables",
+    "description": "Board info",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "board_adult_icon",
+    "syntax": "{$board_adult_icon}",
+    "domain": "board-variables",
+    "description": "Adult verification icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "board_top_image",
+    "syntax": "{$board_top_image}",
+    "domain": "board-variables",
+    "description": "Board top image",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "subject",
+    "syntax": "{$subject}",
+    "domain": "board-variables",
+    "description": "Post title",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "content",
+    "syntax": "{$content}",
+    "domain": "board-variables",
+    "description": "Post content",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "writer",
+    "syntax": "{$writer}",
+    "domain": "board-variables",
+    "description": "Author",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "write_date",
+    "syntax": "{$write_date}",
+    "domain": "board-variables",
+    "description": "Write date",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "hit_count",
+    "syntax": "{$hit_count}",
+    "domain": "board-variables",
+    "description": "View count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "vote",
+    "syntax": "{$vote}",
+    "domain": "board-variables",
+    "description": "Recommendation count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "point_count",
+    "syntax": "{$point_count}",
+    "domain": "board-variables",
+    "description": "Points",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "comment_count",
+    "syntax": "{$comment_count}",
+    "domain": "board-variables",
+    "description": "Comment count",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "notice_icon",
+    "syntax": "{$notice_icon}",
+    "domain": "board-variables",
+    "description": "Notice icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "fixed_icon",
+    "syntax": "{$fixed_icon}",
+    "domain": "board-variables",
+    "description": "Pinned post icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "icon_re",
+    "syntax": "{$icon_re}",
+    "domain": "board-variables",
+    "description": "Reply icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "icon_new",
+    "syntax": "{$icon_new}",
+    "domain": "board-variables",
+    "description": "NEW icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "icon_hit",
+    "syntax": "{$icon_hit}",
+    "domain": "board-variables",
+    "description": "Hot post icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "icon_file",
+    "syntax": "{$icon_file}",
+    "domain": "board-variables",
+    "description": "Attachment icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "icon_lock",
+    "syntax": "{$icon_lock}",
+    "domain": "board-variables",
+    "description": "Secret post icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "member_icon",
+    "syntax": "{$member_icon}",
+    "domain": "board-variables",
+    "description": "Member icon",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "list_bg_color",
+    "syntax": "{$list_bg_color}",
+    "domain": "board-variables",
+    "description": "List background color",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "list_char_color",
+    "syntax": "{$list_char_color}",
+    "domain": "board-variables",
+    "description": "List text color",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "link_color",
+    "syntax": "{$link_color}",
+    "domain": "board-variables",
+    "description": "Link color",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "checkbox",
+    "syntax": "{$checkbox}",
+    "domain": "board-variables",
+    "description": "Checkbox",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_read",
+    "syntax": "{$param_read}",
+    "domain": "board-variables",
+    "description": "Read post parameter",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_write",
+    "syntax": "{$param_write}",
+    "domain": "board-variables",
+    "description": "Write post parameter",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "param_prev",
+    "syntax": "{$param_prev}",
+    "domain": "board-variables",
+    "description": "Previous page",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.board_category",
+    "syntax": "{$form.board_category}",
+    "domain": "board-variables",
+    "description": "Category select form",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.search_key",
+    "syntax": "{$form.search_key}",
+    "domain": "board-variables",
+    "description": "Search keyword form",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.search",
+    "syntax": "{$form.search}",
+    "domain": "board-variables",
+    "description": "Search text form",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "form.search_date",
+    "syntax": "{$form.search_date}",
+    "domain": "board-variables",
+    "description": "Search date form",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_search",
+    "syntax": "{$action_search}",
+    "domain": "board-variables",
+    "description": "Search action",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_category_move",
+    "syntax": "{$action_category_move}",
+    "domain": "board-variables",
+    "description": "Category move action",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_article_move",
+    "syntax": "{$action_article_move}",
+    "domain": "board-variables",
+    "description": "Article move action",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "action_article_copy",
+    "syntax": "{$action_article_copy}",
+    "domain": "board-variables",
+    "description": "Article copy action",
+    "usage": "",
+    "source": "references/variables.md"
+  },
+  {
+    "name": "reply_sort",
+    "syntax": "{$reply_sort}",
+    "domain": "board-variables",
+    "description": "Comment sort",
+    "usage": "",
+    "source": "references/variables.md"
+  }
+]

--- a/docs/red-blue-merge-gates.md
+++ b/docs/red-blue-merge-gates.md
@@ -1,0 +1,29 @@
+# Red Team / Blue Team merge gates
+
+This repository uses GitHub Actions jobs as automatic merge gates for changes targeting `main`.
+
+## Gate model
+
+- **Red Team**: attacker/regression gate. It checks patch whitespace, scans added lines for obvious hardcoded secrets, and blocks critical dependency vulnerabilities.
+- **Blue Team**: deploy-readiness gate. It installs dependencies with `npm ci` and runs `npm run check`.
+- **Deployment Readiness**: fail-closed aggregator. It passes only when both Red Team and Blue Team succeeded.
+
+## Recommended flow
+
+1. Create a feature branch.
+2. Open a pull request to `main`.
+3. Let the Red Team, Blue Team, and Deployment Readiness jobs run.
+4. Enable auto-merge on the PR.
+5. GitHub merges only after all required checks pass.
+
+Avoid direct pushes to `main`; they bypass the PR review surface and make failed gates reactive instead of preventive.
+
+## Required status checks
+
+When branch protection is enabled for `main`, require these contexts:
+
+- `Red Team`
+- `Blue Team`
+- `Deployment Readiness`
+
+Do not require manual reviews if the intended policy is fully automatic merge after the three gates pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "cafe24-smart-design",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cafe24-smart-design",
+      "version": "0.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "cafe24-smart-design",
+  "version": "0.1.0",
+  "description": "Cafe24 Smart Design reference, registry, and validation tools for AI-assisted storefront work.",
+  "type": "module",
+  "private": false,
+  "scripts": {
+    "test": "node --test",
+    "validate:data": "node scripts/validate-data.mjs",
+    "check": "npm run validate:data && npm test"
+  },
+  "keywords": [
+    "cafe24",
+    "smart-design",
+    "ecommerce",
+    "frontend",
+    "ai-agents",
+    "cursor",
+    "claude-code",
+    "copilot"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kimyoungwopo/cafe24-smart-design.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kimyoungwopo/cafe24-smart-design/issues"
+  },
+  "homepage": "https://github.com/kimyoungwopo/cafe24-smart-design#readme",
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/scripts/validate-data.mjs
+++ b/scripts/validate-data.mjs
@@ -1,0 +1,70 @@
+import { readFile } from 'node:fs/promises';
+
+const readJson = async (path) => JSON.parse(await readFile(new URL(`../${path}`, import.meta.url), 'utf8'));
+
+const fail = (message) => {
+  console.error(`✖ ${message}`);
+  process.exitCode = 1;
+};
+
+const assertString = (record, field, label) => {
+  if (typeof record[field] !== 'string' || record[field].trim() === '') {
+    fail(`${label} must include non-empty ${field}`);
+  }
+};
+
+const assertUnique = (records, key, label) => {
+  const seen = new Set();
+  for (const record of records) {
+    if (seen.has(record[key])) fail(`${label} has duplicate ${key}: ${record[key]}`);
+    seen.add(record[key]);
+  }
+};
+
+const modules = await readJson('data/modules.json');
+const variables = await readJson('data/variables.json');
+const modifiers = await readJson('data/modifiers.json');
+
+if (!Array.isArray(modules) || modules.length < 20) fail('data/modules.json must contain at least 20 modules');
+if (!Array.isArray(variables) || variables.length < 80) fail('data/variables.json must contain at least 80 variables');
+if (!Array.isArray(modifiers) || modifiers.length !== 13) fail('data/modifiers.json must contain exactly 13 modifiers');
+
+assertUnique(modules, 'id', 'modules');
+assertUnique(variables, 'name', 'variables');
+assertUnique(modifiers, 'name', 'modifiers');
+
+const variableNames = new Set(variables.map((variable) => variable.name));
+
+for (const module of modules) {
+  assertString(module, 'id', 'module');
+  assertString(module, 'category', module.id);
+  assertString(module, 'description', module.id);
+  assertString(module, 'source', module.id);
+  if (!/^[A-Za-z][A-Za-z0-9_{}]*$/.test(module.id)) fail(`module id has suspicious syntax: ${module.id}`);
+  if (!Array.isArray(module.variables)) fail(`${module.id} variables must be an array`);
+  for (const variable of module.variables) {
+    if (!variableNames.has(variable)) fail(`${module.id} references unknown variable: ${variable}`);
+  }
+}
+
+for (const variable of variables) {
+  assertString(variable, 'name', 'variable');
+  assertString(variable, 'syntax', variable.name);
+  assertString(variable, 'domain', variable.name);
+  assertString(variable, 'description', variable.name);
+  assertString(variable, 'source', variable.name);
+  if (!variable.syntax.startsWith('{$') || !variable.syntax.endsWith('}')) fail(`${variable.name} has invalid Cafe24 syntax`);
+}
+
+for (const modifier of modifiers) {
+  assertString(modifier, 'name', 'modifier');
+  assertString(modifier, 'purpose', modifier.name);
+  assertString(modifier, 'syntax', modifier.name);
+  assertString(modifier, 'example', modifier.name);
+  assertString(modifier, 'source', modifier.name);
+  if (!modifier.syntax.includes(`|${modifier.name}`)) fail(`${modifier.name} syntax must include its pipe modifier name`);
+  if (!modifier.example.includes(`|${modifier.name}`)) fail(`${modifier.name} example must include its pipe modifier name`);
+}
+
+if (process.exitCode) process.exit(process.exitCode);
+console.log(`✓ registry ok: ${modules.length} modules, ${variables.length} variables, ${modifiers.length} modifiers`);

--- a/test/validate-data.test.mjs
+++ b/test/validate-data.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const readJson = async (path) => JSON.parse(await readFile(new URL(`../${path}`, import.meta.url), 'utf8'));
+
+test('registry files expose useful Cafe24 reference data', async () => {
+  const modules = await readJson('data/modules.json');
+  const variables = await readJson('data/variables.json');
+  const modifiers = await readJson('data/modifiers.json');
+
+  assert.ok(modules.length >= 20, 'expected at least 20 modules');
+  assert.ok(variables.length >= 80, 'expected at least 80 variables');
+  assert.equal(modifiers.length, 13, 'expected 13 documented modifiers');
+
+  assert.ok(modules.some((module) => module.id === 'product_listnormal'));
+  assert.ok(variables.some((variable) => variable.name === 'product_name'));
+  const displayModifier = modifiers.find((modifier) => modifier.name === 'display');
+  assert.ok(displayModifier);
+  assert.equal(displayModifier.syntax, '{$v|display}');
+});
+
+test('registry ids are unique and references are internally consistent', async () => {
+  const modules = await readJson('data/modules.json');
+  const variables = await readJson('data/variables.json');
+  const modifiers = await readJson('data/modifiers.json');
+
+  for (const [label, records, key] of [
+    ['module', modules, 'id'],
+    ['variable', variables, 'name'],
+    ['modifier', modifiers, 'name'],
+  ]) {
+    const ids = records.map((record) => record[key]);
+    assert.equal(new Set(ids).size, ids.length, `${label} ids must be unique`);
+  }
+
+  const variableNames = new Set(variables.map((variable) => variable.name));
+  for (const module of modules) {
+    assert.match(module.id, /^[A-Za-z][A-Za-z0-9_{}]*$/);
+    assert.ok(module.category, `${module.id} needs category`);
+    assert.ok(module.description, `${module.id} needs description`);
+    for (const variable of module.variables ?? []) {
+      assert.ok(variableNames.has(variable), `${module.id} references unknown variable ${variable}`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Add machine-readable Cafe24 module, variable, and modifier registries
- Add registry validation/tests and npm check command
- Add Red Team / Blue Team / Deployment Readiness GitHub Actions gates
- Add PR template, docs, MIT license, and contribution guide

## Test Plan
- npm run check
- git diff --check

## Auto-merge policy
- Red Team must pass
- Blue Team must pass
- Deployment Readiness must pass
